### PR TITLE
Register ProfilerController only if profiler service is defined

### DIFF
--- a/ContentfulBundle.php
+++ b/ContentfulBundle.php
@@ -6,8 +6,14 @@
 
 namespace Contentful\ContentfulBundle;
 
+use Contentful\ContentfulBundle\DependencyInjection\Compiler\ProfilerControllerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ContentfulBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new ProfilerControllerPass());
+    }
 }

--- a/DependencyInjection/Compiler/ProfilerControllerPass.php
+++ b/DependencyInjection/Compiler/ProfilerControllerPass.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @copyright 2016 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\ContentfulBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\Config\FileLocator;
+
+class ProfilerControllerPass implements CompilerPassInterface
+{
+    /**
+     * You can modify the container here before it is dumped to PHP code.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (! $container->hasDefinition('profiler')) {
+            return;
+        }
+
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../../Resources/config'));
+        $loader->load('profiler-controller.xml');
+    }
+}

--- a/DependencyInjection/Compiler/ProfilerControllerPass.php
+++ b/DependencyInjection/Compiler/ProfilerControllerPass.php
@@ -14,13 +14,13 @@ use Symfony\Component\Config\FileLocator;
 class ProfilerControllerPass implements CompilerPassInterface
 {
     /**
-     * You can modify the container here before it is dumped to PHP code.
+     * Loads the definition for the ProfilerController when the profiler is present.
      *
      * @param ContainerBuilder $container
      */
     public function process(ContainerBuilder $container)
     {
-        if (! $container->hasDefinition('profiler')) {
+        if (!$container->hasDefinition('profiler')) {
             return;
         }
 

--- a/Resources/config/profiler-controller.xml
+++ b/Resources/config/profiler-controller.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="contentful.profiler_controller" class="Contentful\ContentfulBundle\Controller\ProfilerController">
+            <argument type="service" id="profiler" />
+            <argument type="service" id="templating" />
+        </service>
+    </services>
+</container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,11 +11,6 @@
 
         <service id="contentful.logger.array" class="Contentful\Log\ArrayLogger" public="false" />
 
-        <service id="contentful.profiler_controller" class="Contentful\ContentfulBundle\Controller\ProfilerController">
-            <argument type="service" id="profiler" />
-            <argument type="service" id="templating" />
-        </service>
-
         <service id="contentful.data_collector"
                  class="Contentful\ContentfulBundle\DataCollector\ContentfulDataCollector"
                  public="false"

--- a/Tests/ContainerTrait.php
+++ b/Tests/ContainerTrait.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @copyright 2016 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\ContentfulBundle\Tests;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+trait ContainerTrait
+{
+    protected function getContainer($environment = 'test')
+    {
+        return new ContainerBuilder(new ParameterBag([
+            'kernel.debug' => false,
+            'kernel.bundles' => [],
+            'kernel.cache_dir' => sys_get_temp_dir(),
+            'kernel.environment' => $environment,
+            'kernel.root_dir' => __DIR__.'/../../', // src dir
+        ]));
+    }
+}

--- a/Tests/DependencyInjection/Compiler/ProfilerControllerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ProfilerControllerPassTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @copyright 2016 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\ContentfulBundle\Tests\DependencyInjection\Compiler;
+
+use Contentful\ContentfulBundle\DependencyInjection\Compiler\ProfilerControllerPass;
+use Contentful\ContentfulBundle\Tests\ContainerTrait;
+use Symfony\Component\DependencyInjection\Definition;
+
+class ProfilerControllerPassTest extends \PHPUnit_Framework_TestCase
+{
+    use ContainerTrait;
+
+    public function testProcessWhenProfilerIsNotPresent()
+    {
+        $container = $this->getContainer();
+        $compilerPass = new ProfilerControllerPass;
+
+        $container->addCompilerPass($compilerPass);
+        $compilerPass->process($container);
+
+        $this->assertFalse($container->hasDefinition('contentful.profiler_controller'));
+    }
+
+    public function testProcessWhenProfilerIsPresent()
+    {
+        $container = $this->getContainer();
+        $container->setDefinition('profiler', new Definition());
+        $compilerPass = new ProfilerControllerPass;
+
+        $container->addCompilerPass($compilerPass);
+        $compilerPass->process($container);
+
+        $this->assertTrue($container->hasDefinition('contentful.profiler_controller'));
+    }
+}

--- a/Tests/DependencyInjection/ContentfulExtensionTest.php
+++ b/Tests/DependencyInjection/ContentfulExtensionTest.php
@@ -7,11 +7,12 @@
 namespace Contentful\ContentfulBundle\Tests\DependencyInjection;
 
 use Contentful\ContentfulBundle\DependencyInjection\ContentfulExtension;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Contentful\ContentfulBundle\Tests\ContainerTrait;
 
 class ContentfulExtensionTest extends \PHPUnit_Framework_TestCase
 {
+    use ContainerTrait;
+
     public function loadEmpty()
     {
         $container = $this->getContainer();
@@ -171,16 +172,5 @@ class ContentfulExtensionTest extends \PHPUnit_Framework_TestCase
                 'space' => 'def'
             ]
         ], $container->getParameter('contentful.clients'));
-    }
-
-    public function getContainer()
-    {
-        return new ContainerBuilder(new ParameterBag([
-            'kernel.debug' => false,
-            'kernel.bundles' => [],
-            'kernel.cache_dir' => sys_get_temp_dir(),
-            'kernel.environment' => 'test',
-            'kernel.root_dir' => __DIR__.'/../../', // src dir
-        ]));
     }
 }

--- a/Tests/DependencyInjection/ContentfulExtensionTest.php
+++ b/Tests/DependencyInjection/ContentfulExtensionTest.php
@@ -13,7 +13,7 @@ class ContentfulExtensionTest extends \PHPUnit_Framework_TestCase
 {
     use ContainerTrait;
 
-    public function loadEmpty()
+    public function testLoadEmpty()
     {
         $container = $this->getContainer();
         $extension = new ContentfulExtension;


### PR DESCRIPTION
## Problem

During `cache:clear` command in a production environment an exception is thrown:

```
[Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]     
  The service "contentful.profiler_controller" has a dependency on a non-existe  
  nt service "profiler".          
```
## Solution

We don't need a `ProfilerController` in a production environment. It's only used by Symfony Profiler, so I moved the definition for that controller to a different file and load that file only when `profiler` service is defined.
