### PR TITLE
Fixed a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ public function registerBundles()
 {
     return array(
         // ...
-        new Contenful\ContentfulBundle\ContentfulBundle(),
+        new Contentful\ContentfulBundle\ContentfulBundle(),
         // ...
     );
 }


### PR DESCRIPTION
There was a typo in the README.md which resulted in an error when copying the code into the source.
