### PR TITLE
Compatibility with the PSR-6 branch of contentful.php

### DIFF
--- a/CacheClearer/DeliveryCacheClearer.php
+++ b/CacheClearer/DeliveryCacheClearer.php
@@ -7,37 +7,26 @@
 namespace Contentful\ContentfulBundle\CacheClearer;
 
 use Contentful\Delivery\Cache\CacheClearer;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 
-class DeliveryCacheClearer extends CacheClearer implements CacheClearerInterface
+class DeliveryCacheClearer implements CacheClearerInterface
 {
     /**
-     * @var string
+     * @var CacheClearer
      */
-    private $subDirectory;
+    private $contentfulClearer;
 
     /**
      * DeliveryCacheClearer constructor.
-     *
-     * @param  string $spaceId
-     * @param  string $cacheSubDirectory
      */
-    public function __construct($spaceId, $cacheSubDirectory = '')
+    public function __construct(CacheItemPoolInterface $cacheItemPool)
     {
-        parent::__construct($spaceId);
-
-        $this->subDirectory = $cacheSubDirectory;
+        $this->contentfulClearer = new CacheClearer($cacheItemPool);
     }
 
-    /**
-     * @param string $cacheDir
-     */
     public function clear($cacheDir)
     {
-        if (!empty($this->subDirectory)) {
-            $cacheDir .= '/' . $this->subDirectory;
-        }
-
-        parent::clear($cacheDir);
+        $this->contentfulClearer->clear();
     }
 }

--- a/CacheWarmer/DeliveryCacheWarmer.php
+++ b/CacheWarmer/DeliveryCacheWarmer.php
@@ -8,45 +8,47 @@ namespace Contentful\ContentfulBundle\CacheWarmer;
 
 use Contentful\Delivery\Cache\CacheWarmer;
 use Contentful\Delivery\Client;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
-class DeliveryCacheWarmer extends CacheWarmer implements CacheWarmerInterface
+class DeliveryCacheWarmer implements CacheWarmerInterface
 {
     /**
-     * @var string
+     * @var bool
      */
-    private $subDirectory;
+    private $autoWarmup;
+
+    /**
+     * @var CacheWarmer
+     */
+    private $contentfulWarmer;
 
     /**
      * DeliveryCacheWarmer constructor.
      *
-     * @param  Client $client
-     * @param  string $cacheSubDirectory
+     * @param Client $client
+     * @param CacheItemPoolInterface $cacheItemPool
+     * @param bool $autoWarmup
      */
-    public function __construct(Client $client, $cacheSubDirectory = '')
+    public function __construct(Client $client, CacheItemPoolInterface $cacheItemPool, $autoWarmup)
     {
-        parent::__construct($client);
-
-        $this->subDirectory = $cacheSubDirectory;
+        $this->contentfulWarmer = new CacheWarmer($client, $cacheItemPool);
+        $this->autoWarmup = $autoWarmup;
     }
 
     /**
-     * @param  string $cacheDir
+     * {@inheritdoc}
      */
     public function warmUp($cacheDir)
     {
-        if (!empty($this->subDirectory)) {
-            $cacheDir .= '/' . $this->subDirectory;
-        }
-
-        parent::warmUp($cacheDir);
+        $this->contentfulWarmer->warmUp();
     }
 
     /**
-     * @return bool
+     * {@inheritdoc}
      */
     public function isOptional()
     {
-        return false;
+        return $this->autoWarmup;
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -9,6 +9,7 @@ namespace Contentful\ContentfulBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 class Configuration implements ConfigurationInterface
 {
@@ -102,8 +103,16 @@ class Configuration implements ConfigurationInterface
                   ->info('Override the default HTTP client with a custom Guzzle instance. Service ID as string.')
                   ->cannotBeEmpty()
                 ->end()
-                ->booleanNode('cache')
-                  ->defaultValue(!$this->debug)
+                ->scalarNode('cache')
+                  ->info(Kernel::VERSION_ID >= 31000 ? 'The cache to use. Can either be true, false or the service ID of a PSR-6 compatible cache to use.' : 'The cache to use. Can either be false or the service ID of a PSR-6 compatible cache to use.')
+                  ->defaultValue(Kernel::VERSION_ID >= 31000 ? !$this->debug : false)
+                  ->validate()
+                      ->ifTrue(function ($v) { return true === $v && Kernel::VERSION_ID < 31000; })
+                      ->thenInvalid(sprintf('Cache can only be true on Symfony 3.1 or higher. You are using version %s.', Kernel::VERSION))
+                  ->end()
+                ->end()
+                ->booleanNode('auto_warmup')
+                    ->defaultValue(true)
                 ->end()
             ->end()
         ;

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,13 @@
   "license": "MIT",
   "require": {
     "php": ">=5.5.9",
-    "contentful/contentful": "^2.0",
-    "symfony/framework-bundle": "~2.7|~3.0"
+    "contentful/contentful": "dev-psr-6",
+    "symfony/framework-bundle": "~2.7|~3.0",
+    "symfony/http-kernel": "~2.7|~3.0",
+    "symfony/console": "~2.7|~3.0",
+    "symfony/http-foundation": "~2.7|~3.0",
+    "symfony/dependency-injection": "~2.7|~3.0",
+    "symfony/config": "~2.7|~3.0"
   },
   "require-dev": {
     "jakub-onderka/php-console-highlighter": "^0.3.2",
@@ -25,5 +30,8 @@
     "branch-alias": {
       "dev-master": "2.1.0-dev"
     }
-  }
+  },
+  "repositories": [
+    { "type": "vcs", "url": "https://github.com/rdey/contentful.php" }
+  ]
 }


### PR DESCRIPTION
This updates the bundle to be compatible with the PSR-6 branch of [contentful/contentful.php](https://github.com/contentful/contentful.php) (see PR contentful/contentful.php#181).

It also restricts a number of Symfony packages that this bundle directly depends on to not use Symfony 4 (as it is not yet compatible). This was necessary in order to make the tests pass.