### PR TITLE
Fixed name of data collector

### DIFF
--- a/src/DependencyInjection/Compiler/ProfilerControllerPass.php
+++ b/src/DependencyInjection/Compiler/ProfilerControllerPass.php
@@ -27,7 +27,7 @@ class ProfilerControllerPass implements CompilerPassInterface
             return;
         }
 
-        $container->register('contentful.delivery.profiler_controller', ProfilerController::class)
+        $container->register('contentful.profiler_controller', ProfilerController::class)
             ->setArguments([
                 new Reference('profiler'),
                 new Reference('twig'),

--- a/src/DependencyInjection/ContentfulExtension.php
+++ b/src/DependencyInjection/ContentfulExtension.php
@@ -105,7 +105,7 @@ class ContentfulExtension extends Extension
             ->addArgument(new TaggedIteratorArgument('contentful.delivery.client'))
             ->addArgument(new Parameter('contentful.delivery.clients.info'))
             ->addTag('data_collector', [
-                'id' => 'contentful.delivery',
+                'id' => 'contentful',
                 'template' => '@Contentful/Collector/contentful.html.twig',
                 'priority' => '250',
             ])


### PR DESCRIPTION
Tested with symfony 5.x:
The name of the DataCollector mismatches the one in "ClientDataCollector::getName" which prevents your bundle to show up in the profiler toolbar as well as in the profiler itself.