### PR TITLE
Replace cache/array-adapter with symfony/cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,15 @@
     "require": {
         "php": "^7.4|^8.0",
         "contentful/contentful": "^6.0",
-        "symfony/framework-bundle": "^4.0|^6.0"
+        "psr/log": "^1.1|^2.0|^3.0",
+        "symfony/framework-bundle": "^4.0|^5.0|^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5",
-        "twig/twig": "^3.0",
-        "cache/array-adapter": "^1.0",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "monolog/monolog": "^2.0",
-        "friendsofphp/php-cs-fixer": "^3.0"
+        "phpunit/phpunit": "^8.5",
+        "symfony/cache": "^5.0|^6.0",
+        "twig/twig": "^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -43,12 +44,13 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.1.0-dev"
+            "dev-master": "7.0.x-dev"
         }
     },
     "config": {
         "allow-plugins": {
             "composer/package-versions-deprecated": false
-        }
+        },
+        "sort-packages": true
     }
 }

--- a/tests/Unit/Cache/Delivery/CacheClearerTest.php
+++ b/tests/Unit/Cache/Delivery/CacheClearerTest.php
@@ -15,13 +15,17 @@ use Cache\Adapter\PHPArray\ArrayCachePool;
 use Contentful\ContentfulBundle\Cache\Delivery\CacheClearer;
 use Contentful\Delivery\Client;
 use Contentful\Tests\ContentfulBundle\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\CacheItem;
 
 class CacheClearerTest extends TestCase
 {
     public function testClearer()
     {
-        $items = $this->getCacheData();
-        $cachePool = new ArrayCachePool(null, $items);
+        $cachePool = new ArrayAdapter();
+        $this->prefillCache($cachePool);
 
         $this->assertTrue($cachePool->hasItem('contentful.DELIVERY.cfexampleapi.master.Space.cfexampleapi.__ALL__'));
         $this->assertTrue($cachePool->hasItem('contentful.DELIVERY.cfexampleapi.master.Environment.master.__ALL__'));
@@ -42,34 +46,39 @@ class CacheClearerTest extends TestCase
         $this->assertFalse($cachePool->hasItem('contentful.DELIVERY.cfexampleapi.master.ContentType.cat.__ALL__'));
     }
 
-    private function getCacheData(): array
+    private function prefillCache(CacheItemPoolInterface $cache): void
     {
-        return [
-            'contentful.DELIVERY.cfexampleapi.master.Space.cfexampleapi.__ALL__' => [
-                '{"sys":{"id":"cfexampleapi","type":"Space"},"name":"Contentful Example API"}',
-                [],
-                null,
-            ],
-            'contentful.DELIVERY.cfexampleapi.master.Environment.master.__ALL__' => [
-                '{"sys":{"id":"master","type":"Environment"},"locales":[{"sys":{"id":"2oQPjMCL9bQkylziydLh57","type":"Locale","version":1},"code":"en-US","default":true,"name":"English","fallbackCode":null},{"sys":{"id":"3zpZmkZrHTIekHmXgflXaV","type":"Locale","version":0},"code":"tlh","default":false,"name":"Klingon","fallbackCode":"en-US"}]}',
-                [],
-                null,
-            ],
-            'contentful.DELIVERY.cfexampleapi.master.ContentType.dog.__ALL__' => [
-                '{"sys":{"id":"dog","type":"ContentType","revision":2,"createdAt":"2013-06-27T22:46:13.498Z","updatedAt":"2013-09-02T14:32:11.837Z","environment":{"sys":{"type":"Link","id":"master","linkType":"Environment"}},"space":{"sys":{"type":"Link","id":"cfexampleapi","linkType":"Space"}}},"name":"Dog","description":"Bark!","displayField":"name","fields":[{"id":"name","name":"Name","type":"Text","required":true,"localized":false},{"id":"description","name":"Description","type":"Text","required":false,"localized":false},{"id":"image","name":"Image","type":"Link","required":false,"localized":false,"linkType":"Asset"}]}',
-                [],
-                null,
-            ],
-            'contentful.DELIVERY.cfexampleapi.master.ContentType.human.__ALL__' => [
-                '{"sys":{"id":"human","type":"ContentType","revision":3,"createdAt":"2013-06-27T22:46:14.133Z","updatedAt":"2013-09-02T15:10:26.818Z","environment":{"sys":{"type":"Link","id":"master","linkType":"Environment"}},"space":{"sys":{"type":"Link","id":"cfexampleapi","linkType":"Space"}}},"name":"Human","description":null,"displayField":"name","fields":[{"id":"name","name":"Name","type":"Text","required":true,"localized":false},{"id":"description","name":"Description","type":"Text","required":false,"localized":false},{"id":"likes","name":"Likes","type":"Array","required":false,"localized":false,"items":{"type":"Symbol"}},{"id":"image","name":"Image","type":"Array","required":false,"localized":false,"disabled":true,"items":{"type":"Link","linkType":"Asset"}}]}',
-                [],
-                null,
-            ],
-            'contentful.DELIVERY.cfexampleapi.master.ContentType.cat.__ALL__' => [
-                '{"sys":{"id":"cat","type":"ContentType","revision":8,"createdAt":"2013-06-27T22:46:12.852Z","updatedAt":"2017-07-06T09:58:52.691Z","environment":{"sys":{"type":"Link","id":"master","linkType":"Environment"}},"space":{"sys":{"type":"Link","id":"cfexampleapi","linkType":"Space"}}},"name":"Cat","description":"Meow.","displayField":"name","fields":[{"id":"name","name":"Name","type":"Text","required":true,"localized":true},{"id":"likes","name":"Likes","type":"Array","required":false,"localized":false,"items":{"type":"Symbol"}},{"id":"color","name":"Color","type":"Symbol","required":false,"localized":false},{"id":"bestFriend","name":"Best Friend","type":"Link","required":false,"localized":false,"linkType":"Entry"},{"id":"birthday","name":"Birthday","type":"Date","required":false,"localized":false},{"id":"lifes","name":"Lifes left","type":"Integer","required":false,"localized":false,"disabled":true},{"id":"lives","name":"Lives left","type":"Integer","required":false,"localized":false},{"id":"image","name":"Image","type":"Link","required":false,"localized":false,"linkType":"Asset"}]}',
-                [],
-                null,
-            ],
-        ];
+        $this->createCacheItem(
+            $cache,
+            'contentful.DELIVERY.cfexampleapi.master.Space.cfexampleapi.__ALL__',
+            '{"sys":{"id":"cfexampleapi","type":"Space"},"name":"Contentful Example API"}',
+        );
+        $this->createCacheItem(
+            $cache,
+            'contentful.DELIVERY.cfexampleapi.master.Environment.master.__ALL__',
+            '{"sys":{"id":"master","type":"Environment"},"locales":[{"sys":{"id":"2oQPjMCL9bQkylziydLh57","type":"Locale","version":1},"code":"en-US","default":true,"name":"English","fallbackCode":null},{"sys":{"id":"3zpZmkZrHTIekHmXgflXaV","type":"Locale","version":0},"code":"tlh","default":false,"name":"Klingon","fallbackCode":"en-US"}]}',
+        );
+        $this->createCacheItem(
+            $cache,
+            'contentful.DELIVERY.cfexampleapi.master.ContentType.dog.__ALL__',
+            '{"sys":{"id":"dog","type":"ContentType","revision":2,"createdAt":"2013-06-27T22:46:13.498Z","updatedAt":"2013-09-02T14:32:11.837Z","environment":{"sys":{"type":"Link","id":"master","linkType":"Environment"}},"space":{"sys":{"type":"Link","id":"cfexampleapi","linkType":"Space"}}},"name":"Dog","description":"Bark!","displayField":"name","fields":[{"id":"name","name":"Name","type":"Text","required":true,"localized":false},{"id":"description","name":"Description","type":"Text","required":false,"localized":false},{"id":"image","name":"Image","type":"Link","required":false,"localized":false,"linkType":"Asset"}]}',
+        );
+        $this->createCacheItem(
+            $cache,
+            'contentful.DELIVERY.cfexampleapi.master.ContentType.human.__ALL__',
+            '{"sys":{"id":"human","type":"ContentType","revision":3,"createdAt":"2013-06-27T22:46:14.133Z","updatedAt":"2013-09-02T15:10:26.818Z","environment":{"sys":{"type":"Link","id":"master","linkType":"Environment"}},"space":{"sys":{"type":"Link","id":"cfexampleapi","linkType":"Space"}}},"name":"Human","description":null,"displayField":"name","fields":[{"id":"name","name":"Name","type":"Text","required":true,"localized":false},{"id":"description","name":"Description","type":"Text","required":false,"localized":false},{"id":"likes","name":"Likes","type":"Array","required":false,"localized":false,"items":{"type":"Symbol"}},{"id":"image","name":"Image","type":"Array","required":false,"localized":false,"disabled":true,"items":{"type":"Link","linkType":"Asset"}}]}',
+        );
+        $this->createCacheItem(
+            $cache,
+            'contentful.DELIVERY.cfexampleapi.master.ContentType.cat.__ALL__',
+            '{"sys":{"id":"cat","type":"ContentType","revision":8,"createdAt":"2013-06-27T22:46:12.852Z","updatedAt":"2017-07-06T09:58:52.691Z","environment":{"sys":{"type":"Link","id":"master","linkType":"Environment"}},"space":{"sys":{"type":"Link","id":"cfexampleapi","linkType":"Space"}}},"name":"Cat","description":"Meow.","displayField":"name","fields":[{"id":"name","name":"Name","type":"Text","required":true,"localized":true},{"id":"likes","name":"Likes","type":"Array","required":false,"localized":false,"items":{"type":"Symbol"}},{"id":"color","name":"Color","type":"Symbol","required":false,"localized":false},{"id":"bestFriend","name":"Best Friend","type":"Link","required":false,"localized":false,"linkType":"Entry"},{"id":"birthday","name":"Birthday","type":"Date","required":false,"localized":false},{"id":"lifes","name":"Lifes left","type":"Integer","required":false,"localized":false,"disabled":true},{"id":"lives","name":"Lives left","type":"Integer","required":false,"localized":false},{"id":"image","name":"Image","type":"Link","required":false,"localized":false,"linkType":"Asset"}]}',
+        );
+    }
+
+    private function createCacheItem(CacheItemPoolInterface $cache, string $key, string $value): void
+    {
+        $cacheItem = $cache->getItem($key);
+        $cacheItem->set($value);
+        $cache->save($cacheItem);
     }
 }

--- a/tests/Unit/Cache/Delivery/CacheWarmerTest.php
+++ b/tests/Unit/Cache/Delivery/CacheWarmerTest.php
@@ -11,31 +11,31 @@ declare(strict_types=1);
 
 namespace Contentful\Tests\ContentfulBundle\Unit\Cache\Delivery;
 
-use Cache\Adapter\PHPArray\ArrayCachePool;
 use Contentful\ContentfulBundle\Cache\Delivery\CacheWarmer;
 use Contentful\Delivery\Client;
 use Contentful\Tests\ContentfulBundle\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class CacheWarmerTest extends TestCase
 {
     public function testWarmer()
     {
-        $items = [];
         $client = new Client('b4c0n73n7fu1', 'cfexampleapi', 'master');
-        $warmer = new CacheWarmer($client, new ArrayCachePool(null, $items), false, false);
+        $cache = new ArrayAdapter();
+        $warmer = new CacheWarmer($client, $cache, false, false);
         $this->assertFalse($warmer->isOptional());
 
         $warmer->warmUp('');
 
-        $this->assertArrayHasKey('contentful.DELIVERY.cfexampleapi.master.Space.cfexampleapi.__ALL__', $items);
-        $this->assertJson($items['contentful.DELIVERY.cfexampleapi.master.Space.cfexampleapi.__ALL__'][0]);
-        $this->assertArrayHasKey('contentful.DELIVERY.cfexampleapi.master.Environment.master.__ALL__', $items);
-        $this->assertJson($items['contentful.DELIVERY.cfexampleapi.master.Environment.master.__ALL__'][0]);
-        $this->assertArrayHasKey('contentful.DELIVERY.cfexampleapi.master.ContentType.dog.__ALL__', $items);
-        $this->assertJson($items['contentful.DELIVERY.cfexampleapi.master.ContentType.dog.__ALL__'][0]);
-        $this->assertArrayHasKey('contentful.DELIVERY.cfexampleapi.master.ContentType.human.__ALL__', $items);
-        $this->assertJson($items['contentful.DELIVERY.cfexampleapi.master.ContentType.human.__ALL__'][0]);
-        $this->assertArrayHasKey('contentful.DELIVERY.cfexampleapi.master.ContentType.cat.__ALL__', $items);
-        $this->assertJson($items['contentful.DELIVERY.cfexampleapi.master.ContentType.cat.__ALL__'][0]);
+        $this->assertTrue($cache->hasItem('contentful.DELIVERY.cfexampleapi.master.Space.cfexampleapi.__ALL__'));
+        $this->assertJson($cache->getItem('contentful.DELIVERY.cfexampleapi.master.Space.cfexampleapi.__ALL__')->get());
+        $this->assertTrue($cache->hasItem('contentful.DELIVERY.cfexampleapi.master.Environment.master.__ALL__'));
+        $this->assertJson($cache->getItem('contentful.DELIVERY.cfexampleapi.master.Environment.master.__ALL__')->get());
+        $this->assertTrue($cache->hasItem('contentful.DELIVERY.cfexampleapi.master.ContentType.dog.__ALL__'));
+        $this->assertJson($cache->getItem('contentful.DELIVERY.cfexampleapi.master.ContentType.dog.__ALL__')->get());
+        $this->assertTrue($cache->hasItem('contentful.DELIVERY.cfexampleapi.master.ContentType.human.__ALL__'));
+        $this->assertJson($cache->getItem('contentful.DELIVERY.cfexampleapi.master.ContentType.human.__ALL__')->get());
+        $this->assertTrue($cache->hasItem('contentful.DELIVERY.cfexampleapi.master.ContentType.cat.__ALL__'));
+        $this->assertJson($cache->getItem('contentful.DELIVERY.cfexampleapi.master.ContentType.cat.__ALL__')->get());
     }
 }


### PR DESCRIPTION
Replace cache/array-adapter with symfony/cache because the array-adapter package is not updated any more. From the php cache main repository:

> Back in 2016, this was the first library supporting PSR-6. We created Symfony bundles and made many great libraries in the PHP-cache organization. This was a few years ago and the library is not activly maintained. Starting a new project one should consider using the more performant and activly supported [Symfony Cache](https://symfony.com/doc/current/components/cache.html).
> https://github.com/php-cache/cache#php-cache

See also https://github.com/contentful/contentful-core.php/pull/53 and https://github.com/contentful/contentful.php/pull/309