### PR TITLE
Remove symfony deprecations for incompatible method declarations

### DIFF
--- a/src/Cache/Delivery/CacheWarmer.php
+++ b/src/Cache/Delivery/CacheWarmer.php
@@ -46,9 +46,9 @@ class CacheWarmer implements CacheWarmerInterface
     /**
      * {@inheritdoc}
      */
-    public function warmUp($cacheDir)
+    public function warmUp($cacheDir): array
     {
-        $this->warmer->warmUp($this->cacheContent);
+        return $this->warmer->warmUp($this->cacheContent);
     }
 
     /**

--- a/src/Command/Delivery/DebugCommand.php
+++ b/src/Command/Delivery/DebugCommand.php
@@ -60,7 +60,7 @@ class DebugCommand extends Command
     /**
      * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/src/Command/Delivery/InfoCommand.php
+++ b/src/Command/Delivery/InfoCommand.php
@@ -36,7 +36,7 @@ class InfoCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $io->title('Contentful clients');


### PR DESCRIPTION
This is my first ever pull request !
This PR fix deprecations trigered by Symfony on version 6 / php 8.1

Do you need more info about this ?