### PR TITLE
[Commands] deprecations symfony 6.1

### DIFF
--- a/src/Command/Delivery/DebugCommand.php
+++ b/src/Command/Delivery/DebugCommand.php
@@ -26,8 +26,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class DebugCommand extends Command
 {
-    protected static $defaultName = 'contentful:delivery:debug';
-
     /**
      * @var Client[]
      */
@@ -41,7 +39,7 @@ class DebugCommand extends Command
      */
     public function __construct($clients, $configurations = [])
     {
-        parent::__construct(self::$defaultName);
+        parent::__construct();
 
         $availableNames = \array_keys($configurations);
         foreach ($clients as $index => $client) {
@@ -49,6 +47,7 @@ class DebugCommand extends Command
             $this->clients[$name] = $client;
         }
 
+        $this->setName('contentful:delivery:debug');
         $this->setDescription('Shows information about data coming from a certain client');
         $this->addArgument(
             'client-name',

--- a/src/Command/Delivery/InfoCommand.php
+++ b/src/Command/Delivery/InfoCommand.php
@@ -18,8 +18,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class InfoCommand extends Command
 {
-    protected static $defaultName = 'contentful:delivery:info';
-
     /**
      * @var array
      */
@@ -27,8 +25,9 @@ class InfoCommand extends Command
 
     public function __construct(array $info)
     {
-        parent::__construct(self::$defaultName);
+        parent::__construct();
 
+        $this->setName('contentful:delivery:info');
         $this->setDescription('Shows information about the configured Contentful delivery clients');
         $this->info = $info;
     }


### PR DESCRIPTION
The `$defaultName` property in commands has been [deprecated](https://github.com/symfony/symfony/commit/ca3458c8781eafd9ff40bac50a254334e526dc10) in Symfony 6.1

This repository is using php 7.4, we can't use the new `AsCommand`. The workaround is to set the name in construct.