### PR TITLE
Allow installation of contentful/contentful ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.4|^8.0",
-        "contentful/contentful": "^6.0",
+        "contentful/contentful": "^6.0|^7.0",
         "psr/log": "^1.1|^2.0|^3.0",
         "symfony/framework-bundle": "^4.0|^5.4|^6.0"
     },


### PR DESCRIPTION
Since [this issue on `contentful/contentful`](https://github.com/contentful/contentful.php/issues/315) has been fixed, this library should be updated to also allow `^7.0` of that package to be installed so we can use it in projects on PHP 8.1 and above.