### PR TITLE
Fix deprecation

### DIFF
--- a/src/ContentfulBundle.php
+++ b/src/ContentfulBundle.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ContentfulBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new ProfilerControllerPass());
     }


### PR DESCRIPTION
### WHY

Resolves the following warning when used with Symfony 7:

```
[2024-11-03T04:46:18.378993+00:00] deprecation.INFO: User Deprecated: Method 
"Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. 
Do the same in child class "Contentful\ContentfulBundle\ContentfulBundle" now to avoid 
errors or add an explicit @return annotation to suppress this message. {"exception":"[object] (ErrorException(code: 0): 
User Deprecated: Method \"Symfony\\Component\\HttpKernel\\Bundle\\Bundle::build()\" 
might add \"void\" as a native return type declaration in the future. Do the same in 
child class \"Contentful\\ContentfulBundle\\ContentfulBundle\" now to avoid 
errors or add an explicit @return annotation to suppress this message. 
at /var/www/html/member-portal/vendor/symfony/error-handler/DebugClassLoader.php:341)"}
```

